### PR TITLE
Avoid crash on actor creation; token item activation

### DIFF
--- a/module/game/effect-flags.js
+++ b/module/game/effect-flags.js
@@ -694,7 +694,7 @@ function checkActorTokenSizeAdjustment(actor) {
         const newSize = sizes[newIndex];
         
         foundry.utils.setProperty(actor, "system.traits.size", newSize);
-        foundry.utils.setProperty(actor.overrides, "system.traits.size", newSize);
+        foundry.utils.setProperty(actor, "overrides.system.traits.size", newSize);
     }
 }
 

--- a/module/item-properties.js
+++ b/module/item-properties.js
@@ -38,7 +38,7 @@ export function targetsSingleToken(item) {
 }
 
 export function isSelfTarget(item) {
-    return item.system.target.type === "self";
+    return item.system.target?.type === "self";
 }
 
 export function isSelfRange(item) {


### PR DESCRIPTION
Crashes occur on documents which Foundry considers valid.

Reproduction steps:

```js
(async () => {
	const scene = await Scene.create({name: "Test Scene", active: true, padding: 0}, {renderSheet: false})
	await scene.activate()
   
	// First crash; `module/game/effect-flags.js`
	const actor = await Actor.create({name: "Test", type: "character"});

	await actor.createEmbeddedDocuments("Item", [{name: "Test", type: "feat"}]);

	const tokenName = `${actor.name} (TOKEN)`
	const td = await actor.getTokenDocument({name: tokenName, x: scene.width / 2, y: scene.height / 2})
	const token = await td.constructor.create(td, {parent: canvas.scene})

	// Second crash; `module/item-properties.js`
	token.actor.items.contents[0].use();
})()
```

Note that this does not fix the _class_ of bugs; there may be similar issues which require similar fixes. These were the two standouts I found during basic use.