### PR TITLE
refactor: add active effect description transfer

### DIFF
--- a/module/game/active-effects.js
+++ b/module/game/active-effects.js
@@ -45,6 +45,15 @@ export async function applyTargetEffects(item, applicationType, allTargetActors,
             },
             extraData || {}
         );
+        
+        // For compatibility with DF Convenient effect descriptions and Visual Active Effects descriptions
+        if (foundry.utils.hasProperty(effect.flags, "convenientDescription")) {
+            data.flags["convenientDescription"] = effect.flags["convenientDescription"];
+        }
+
+        if (foundry.utils.hasProperty(effect.flags, "visual-active-effects")) {
+            data.flags["visual-active-effects"] = effect.flags["visual-active-effects"];
+        }
 
         return { data, rolls };
     };


### PR DESCRIPTION
These changes enhance WIRE so that it keeps effect descriptions from Convenient Effects and Visual Active Effects when applying them onto a target.

Resolves #41 